### PR TITLE
fix albumArtist parameter in scrobble payload

### DIFF
--- a/scripts/Edit Last.fm Scrobbles.user.js
+++ b/scripts/Edit Last.fm Scrobbles.user.js
@@ -244,7 +244,7 @@
         if (album)
             data += "&album=" + encodedAlbum;
         if (albumArtist)
-            data += "&albumartist=" + encodedAlbumArtist;
+            data += "&albumArtist=" + encodedAlbumArtist;
 
         if (mainItemsSame)
             trackinfo.querySelector(".more-item--delete").click();


### PR DESCRIPTION
The Last.fm API [expects](https://www.last.fm/api/show/track.scrobble) the parameter to be given as "albumArtist" and ignores the parameter if capitalized differently, defaulting to the track artist (shown in the response as blank).

<img width="479" height="104" alt="image" src="https://github.com/user-attachments/assets/c17d1d58-20b4-4057-a6a9-88a02a7f332f" />
<img width="621" height="104" alt="image" src="https://github.com/user-attachments/assets/f20f9ab1-e80b-4a70-b9e6-5f865957ac48" />

