### PR TITLE
Fix crash for tracks without albums

### DIFF
--- a/scripts/Edit Last.fm Scrobbles.user.js
+++ b/scripts/Edit Last.fm Scrobbles.user.js
@@ -112,12 +112,12 @@
 
         var album = trackinfo.querySelector(".chartlist-album > a")?.title || "";
         if (!album) {
-            var coverUrl = trackinfo.querySelector(".cover-art")?.href.split("/")?.pop();
+            var coverUrl = trackinfo.querySelector(".cover-art")?.href?.split("/")?.pop();
             if (coverUrl)
                 album = escapeHref(coverUrl);
         }
 
-        var albumArtistUrlParts = trackinfo.querySelector(".cover-art,.chartlist-album > a")?.href.split("/");
+        var albumArtistUrlParts = trackinfo.querySelector(".cover-art,.chartlist-album > a")?.href?.split("/");
         var albumArtistUrlPart = albumArtistUrlParts?.[albumArtistUrlParts.indexOf("music") + 1] ?? "";
         var albumArtistParams = new URLSearchParams(`q=${albumArtistUrlPart}`);
         var albumArtist = albumArtistParams.get("q");


### PR DESCRIPTION
It seems the latest update broke editing tracks without albums:

https://github.com/user-attachments/assets/2d0a65fa-690a-4f19-8a3c-569eb2ae6bf7

I added the missing operators `?.`

p.s. I didn't increase the script version, but I can do it